### PR TITLE
Consistent fingerprint format and major speed improvement

### DIFF
--- a/scanner.php
+++ b/scanner.php
@@ -21,20 +21,6 @@
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-/* Calculate CRC32C value for $word */
-function crc32c_of_string($word)
-{
-	$len = strlen($word);
-	$crc = 0xFFFFFFFF;
-	for ($i = 0; $i < $len; $i++)
-	{
-		$crc = $crc ^ ord($word[$i]);
-		for ($j = 7; $j >= 0; $j--)
-			$crc = ($crc >> 1) ^ (0x82F63B78 & -($crc & 1));
-	}
-	return $crc ^ 0xFFFFFFFF;
-}
-
 /* Convert case to lowercase, and return zero if it isn't a letter or number
 Do it fast and independent from the locale configuration (avoid string.h) */
 function normalize($Byte)
@@ -45,14 +31,6 @@ function normalize($Byte)
 	if ($Byte >= "a") return $Byte;
 	if (($Byte >= "A") && ($Byte <= "Z")) return strtolower($Byte);
 	return "";
-}
-
-function smaller_hash($window)
-{
-	$out = 0xFFFFFFFF;
-	for ($i = 0; $i < count($window); $i++)
-		if ($window[$i] < $out) $out = $window[$i];
-	return $out;
 }
 
 /* Calculate CRC32C value for an int32 */
@@ -136,14 +114,14 @@ function calc_wfp($filename)
 		{
 
 			/* Add fingerprint to the window */
-			$window[$window_ptr++] = crc32c_of_string($gram);
+			$window[$window_ptr++] = hexdec(hash('crc32c', $gram));
 
 			/* Got a full window? */
 			if ($window_ptr >= $WINDOW)
 			{
 
 				/* Add hash */
-				$hash = smaller_hash($window);
+				$hash = \min($window);
 				if ($hash != $last_hash)
 				{
 					$last_hash = $hash;

--- a/scanner.php
+++ b/scanner.php
@@ -150,10 +150,10 @@ function calc_wfp($filename)
 					$hash = crc32c_of_int32($hash);
 					if ($line != $last_line)
 					{
-						$out .= "\n$line=".dechex($hash);
+						$out .= "\n$line=".sprintf("%08x", $hash);
 						$last_line = $line;
 					}
-					else $out .= ",".dechex($hash);
+					else $out .= ",".sprintf("%08x", $hash);
 
 					if ($counter++ >= $LIMIT) break;
 				}


### PR DESCRIPTION
This PR provides two things:

## Zero-padding of fingerprints

The other fingerprinting implementations (Java, Python, C, etc.) always zero-pad their hex strings, such as `85=06ece383,f87358c1`. This PR ensures that this is done in the PHP implementation as well (previously, the output would be `85=6ece383,f87358c1`.

## Speed improvement

By using the `hash('crc32c')` built-in in PHP 7.4, the performance can be greatly increased compared to using a user-provided function. See the benchmark below for the results of scanning the Linux kernel source, where the scanning time is reduced from 46 minutes to 10 minutes. The only downside is that this requires PHP 7.4 or later.

Before:
```
php -d memory_limit=8589934592 scanner.php /scratch/linux  2695.49s user 74.64s system 99% cpu 46:11.92 total
```
After:
```
php -d memory_limit=8589934592 scanner.php /scratch/linux  534.92s user 73.99s system 99% cpu 10:09.32 total
```

I have verified that the output is the same before and after my changes (well, apart from the zero-padded lines that are fixed, of course).